### PR TITLE
Need Docker v1.12 for new log options

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,7 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
       sudo sysctl -w vm.max_map_count=262144
+      sudo /etc/init.d/docker restart v1.12.3
   SHELL
 
 


### PR DESCRIPTION
`ailispaw/barge` のご利用ありがとうございます。
Barge デフォルトの Docker では `--log-opt` でエラーが出ているようでしたので、
パッチを当てました。
ご参考になれば幸いです。